### PR TITLE
SCRUM-64: Add page layout with skeleton header, app logo, and user menu

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -1,0 +1,6 @@
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,0 +1,13 @@
+import UserMenu from "../UserMenu/UserMenu";
+
+import "./Header.css";
+
+export default function Header() {
+
+  return (
+    <div className="header">
+      <div>ResumAI Logo</div>
+      <UserMenu />
+    </div>
+  )
+}

--- a/frontend/src/components/Layout/Layout.css
+++ b/frontend/src/components/Layout/Layout.css
@@ -1,0 +1,19 @@
+.layout {
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #bbb;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  min-height: 300px;
+  width: 450px;
+  padding: 2rem;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,0 +1,16 @@
+import { Outlet } from "react-router-dom";
+
+import Header from "../Header/Header";
+
+import "./Layout.css";
+
+export default function Layout() {
+  return (
+    <div className="layout">
+      <Header />
+      <main className="main">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/ResumeTailorForm/ResumeTailorForm.css
+++ b/frontend/src/components/ResumeTailorForm/ResumeTailorForm.css
@@ -1,17 +1,6 @@
 .resume-tailor-form {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  border-radius: 10px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  padding: 2rem;
-  min-width: 450px;
 }
 
-.app-log {
-  height: 100px;
-  resize: none;
-  width: 100%;
-}

--- a/frontend/src/components/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/UserMenu/UserMenu.tsx
@@ -1,0 +1,15 @@
+import { useAuth } from "../../contexts/AuthContext"
+
+export default function UserMenu() {
+  const { userInfo } = useAuth();
+
+  if (!userInfo) {
+    return null;
+  }
+
+  return (
+    <div>
+      Welcome, {userInfo?.firstName}
+    </div>
+  )
+}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -4,15 +4,19 @@ import ProtectedRoute from "./ProtectedRoute";
 
 import ResumeTailorForm from "../components/ResumeTailorForm/ResumeTailorForm";
 import LoginButton from "../components/GoogleLoginButton/GoogleLoginButton";
+import Layout from "../components/Layout/Layout";
 
 export default function AppRoutes() {
   return (
     <Routes>
-      <Route path="/login" element={<LoginButton />} />
+      {/* Layout is a wrapper/container for all pages */}
+      <Route path="/" element={<Layout />}>
+        <Route path="/login" element={<LoginButton />} />
 
-      {/* All routes below require user to be authenticated */}
-      <Route element={<ProtectedRoute />}>
-        <Route path="/tailor-resume" element={<ResumeTailorForm />} />
+        {/* All routes below require user to be authenticated */}
+        <Route element={<ProtectedRoute />}>
+          <Route path="/tailor-resume" element={<ResumeTailorForm />} />
+        </Route>
       </Route>
     </Routes>
   );


### PR DESCRIPTION
### [SCRUM-64](https://tailorai.atlassian.net/browse/SCRUM-64)

### Summary

Add a page layout that contains all pages/routes. The layout contains:

- Header
    - Contains the app logo and the user menu (skeleton for now)

- Main body
    - Each route is rendered in this section (e.g. Login, Tailor Resume Form, etc.)

<img width="741" height="905" alt="image" src="https://github.com/user-attachments/assets/7b3f2916-e989-413c-b65d-c5d129cdf675" />


[SCRUM-64]: https://tailorai.atlassian.net/browse/SCRUM-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ