### PR TITLE
add Factories and refactor test setup to conftest file

### DIFF
--- a/backend/tailor/tests/conftest.py
+++ b/backend/tailor/tests/conftest.py
@@ -1,0 +1,29 @@
+import pytest
+from pathlib import Path
+import shutil
+
+from factories import UserFactory, ResumeFactory
+
+
+@pytest.fixture(autouse=True)
+def media_root_override(settings):
+    settings.MEDIA_ROOT = Path(settings.BASE_DIR) / "tailor/tests/test_media_root/uploads"
+
+    yield
+
+    tailored_resumes_path = Path(settings.MEDIA_ROOT) / "tailored_resumes"
+    if tailored_resumes_path.exists():
+        shutil.rmtree(tailored_resumes_path)
+
+
+@pytest.fixture
+def resume_object(request, db):
+    filename = request.param
+    filetype = filename.split('.')[-1].upper()
+    filepath = f"resumes/{filename}"
+    return ResumeFactory(
+        name="Demo_Resume",
+        file=filepath,
+        file_type=filetype,
+        user=UserFactory(username="Test_User"),
+    )

--- a/backend/tailor/tests/factories.py
+++ b/backend/tailor/tests/factories.py
@@ -1,0 +1,20 @@
+import factory
+from django.contrib.auth.models import User
+from tailor.models import Resume
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = User
+
+    username = factory.Faker('user_name')
+
+
+class ResumeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Resume
+
+    name = "Demo_Resume"
+    file = "resumes/test_arvind_resume.pdf"
+    file_type = "PDF"
+    user = factory.SubFactory(UserFactory)

--- a/backend/tailor/tests/test_models.py
+++ b/backend/tailor/tests/test_models.py
@@ -1,49 +1,15 @@
-import shutil
-from pathlib import Path
 import pytest
-from django.conf import settings
-from django.contrib.auth.models import User
-from tailor.models import Resume, TailoredResume
-
-
-@pytest.fixture(autouse=True)
-def media_root_override(settings):
-    settings.MEDIA_ROOT = Path(settings.BASE_DIR) / "tailor/tests/test_media_root/uploads"
-
-    yield
-
-    tailored_resumes_path = Path(settings.MEDIA_ROOT) / "tailored_resumes"
-    if tailored_resumes_path.exists():
-        shutil.rmtree(tailored_resumes_path)
-
-
-@pytest.fixture
-def user_data(db) -> User:
-    return User.objects.create_user("Test_User")
-
-
-@pytest.fixture
-def resume_data( request, db, user_data):
-    filename = request.param
-    filetype = filename.split('.')[-1].upper()
-    filepath = f"resumes/{filename}"
-    return {
-        "name": "Demo_Resume",
-        "file": filepath,
-        "file_type": filetype,
-        "user": user_data,
-    }
 
 
 class TestResume:
 
-    @pytest.mark.parametrize("resume_data", [
+    @pytest.mark.parametrize("resume_object", [
         "test_arvind_resume.pdf",
         "test_arvind_resume.docx",
         "test_max_resume.pdf",
     ], indirect=True)
-    def test_create_resume(self, db, resume_data):
-        resume = Resume(**resume_data)
+    def test_create_resume(self, db, resume_object):
+        resume = resume_object
         assert resume.name == "Demo_Resume"
         assert resume.file_type == resume.file.name.split('.')[-1].upper()
         assert resume.get_text() != ""


### PR DESCRIPTION
Adds the ability to create factories of Model objects (will be useful in future tests that will require creating Resume and TailoredResume objects for API and tailoring testing)

Also refactored testing setup so it can be running on all tests without duplicating code