### PR TITLE
SCRUM-91: Restrict user-specific API endpoints to logged-in user

### DIFF
--- a/backend/resumai/settings.py
+++ b/backend/resumai/settings.py
@@ -125,6 +125,7 @@ if os.environ.get('GITHUB_WORKFLOW'):
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
+        "tailor.permissions.IsOwner",
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",

--- a/backend/tailor/api/views.py
+++ b/backend/tailor/api/views.py
@@ -135,9 +135,6 @@ class TailorResumeView(APIView):
         resume_id: int = int(request.data["resume_id"])
         job_posting_url: str = request.data["job_posting_url"]
 
-        # Validate that logged in user matches the user referenced in the request URL
-        # TODO: request.user.id == user_id  (must implement user login/auth first)
-
         try:
             tailored_resume = TailoredResume.objects.create_from_params(
                 user_id=user_id,

--- a/backend/tailor/permissions.py
+++ b/backend/tailor/permissions.py
@@ -13,5 +13,4 @@ class IsOwner(BasePermission):
             return url_user_id == request.user.id
         else:
             return True
-
         

--- a/backend/tailor/permissions.py
+++ b/backend/tailor/permissions.py
@@ -1,0 +1,17 @@
+from rest_framework.permissions import BasePermission
+
+class IsOwner(BasePermission):
+    """
+    Permission is granted if user in URL matches logged-in user
+    or if user_id is not present in URL.
+    """
+
+    def has_permission(self, request, view):
+        url_user_id = view.kwargs.get("user_id")
+
+        if url_user_id:
+            return url_user_id == request.user.id
+        else:
+            return True
+
+        

--- a/backend/tailor/permissions.py
+++ b/backend/tailor/permissions.py
@@ -13,4 +13,3 @@ class IsOwner(BasePermission):
             return url_user_id == request.user.id
         else:
             return True
-        


### PR DESCRIPTION
### [SCRUM-91](https://tailorai.atlassian.net/browse/SCRUM-91)

### Summary:
If a user_id is part of the API endpoint URL (e.g. /tailor/users/2/tailor-resume/), then verify that the logged-in user matches that URL user. This ensures that API views that access user data are restricted to the logged-in user.

[SCRUM-91]: https://tailorai.atlassian.net/browse/SCRUM-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ