### PR TITLE
SCRUM-93: Remove user_id from API endpoint URLs

### DIFF
--- a/backend/tailor/urls.py
+++ b/backend/tailor/urls.py
@@ -9,27 +9,27 @@ from tailor.api.views import (
 
 urlpatterns = [
     path(
-        "users/<int:user_id>/resumes/",
+        "resumes/",
         UserResumeListView.as_view(),
         name="user-resumes",
     ),
     path(
-        "users/<int:user_id>/resumes/upload/",
+        "resumes/upload/",
         UserResumeUploadView.as_view(),
         name="user-resume-upload",
     ),
     path(
-        "users/<int:user_id>/tailor-resume/",
+        "tailor-resume/",
         TailorResumeView.as_view(),
         name="tailor-resume",
     ),
     path(
-        "users/<int:user_id>/tailored-resumes/",
+        "tailored-resumes/",
         TailoredResumeListView.as_view(),
         name="tailored-resumes",
     ),
     path(
-        "users/<int:user_id>/tailored-resume/<int:tailored_resume_id>/download/",
+        "tailored-resume/<int:tailored_resume_id>/download/",
         TailoredResumeDownloadView.as_view(),
         name="tailored-resume-download",
     ),

--- a/frontend/src/api/resumeApi.ts
+++ b/frontend/src/api/resumeApi.ts
@@ -1,25 +1,23 @@
-import { useAuth } from '../contexts/AuthContext';
 import useFetchWithAuth from '../hooks/useFetchWithAuth';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const TAILOR_API_BASE_URL = `${API_BASE_URL}/tailor`;
 
 export function useResumeApi() {
-  const { userInfo } = useAuth();
   const fetchWithAuth = useFetchWithAuth();
 
   return {
     getUserResumes() {
-      return fetchWithAuth(`${TAILOR_API_BASE_URL}/users/${userInfo?.id}/resumes/`);
+      return fetchWithAuth(`${TAILOR_API_BASE_URL}/resumes/`);
     },
     uploadUserResume(formData: FormData) {
-      return fetchWithAuth(`${TAILOR_API_BASE_URL}/users/${userInfo?.id}/resumes/upload/`, {
+      return fetchWithAuth(`${TAILOR_API_BASE_URL}/resumes/upload/`, {
         method: "POST",
         body: formData
       });
     },
     tailorUserResume(resumeId: number, jobPostingUrl: string) {
-      return fetchWithAuth(`${TAILOR_API_BASE_URL}/users/${userInfo?.id}/tailor-resume/`, {
+      return fetchWithAuth(`${TAILOR_API_BASE_URL}/tailor-resume/`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -31,10 +29,10 @@ export function useResumeApi() {
       });
     },
     getTailoredUserResumes() {
-      return fetchWithAuth(`${TAILOR_API_BASE_URL}/users/${userInfo?.id}/tailored-resumes/`);
+      return fetchWithAuth(`${TAILOR_API_BASE_URL}/tailored-resumes/`);
     },
     downloadTailoredUserResume(tailoredResumeId: number) {
-      return fetchWithAuth(`${TAILOR_API_BASE_URL}/users/${userInfo?.id}/tailored-resume/${tailoredResumeId}/download/`);
+      return fetchWithAuth(`${TAILOR_API_BASE_URL}/tailored-resume/${tailoredResumeId}/download/`);
     }
   };
 }


### PR DESCRIPTION
### [SCRUM-93](https://tailorai.atlassian.net/browse/SCRUM-93)

### Summary:
Remove user_id kwargs from all API endpoint URLs and update API views to user request.user instead.

[SCRUM-93]: https://tailorai.atlassian.net/browse/SCRUM-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ