### PR TITLE
SCRUM-94: Tailored Resumes Context

### DIFF
--- a/backend/tailor/api/views.py
+++ b/backend/tailor/api/views.py
@@ -143,10 +143,11 @@ class TailorResumeView(APIView):
                 job_posting_url=job_posting_url
             )
 
+            tailored_resume_serializer = TailoredResumeSerializer(tailored_resume)
+            tailored_resume_json_data = {"tailoredResume": tailored_resume_serializer.data}
+            
             return Response(
-                {
-                    "tailored_resume_id": tailored_resume.id,
-                },
+                tailored_resume_json_data,
                 status=status.HTTP_201_CREATED
             )
         # TODO remove Exception from error handling here

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { GoogleOAuthProvider } from "@react-oauth/google";
 
 import AppRoutes from "./routes/AppRoutes";
 import { ResumesContextProvider } from "./contexts/ResumesContext";
+import { TailoredResumesContextProvider } from "./contexts/TailoredResumesContext";
 
 import "./App.css";
 import "./assets/styles/shared.css";
@@ -16,7 +17,9 @@ function App() {
       <AuthProvider>
         <BrowserRouter>
           <ResumesContextProvider>
-            <AppRoutes />
+            <TailoredResumesContextProvider>
+              <AppRoutes />
+            </TailoredResumesContextProvider>
           </ResumesContextProvider>
         </BrowserRouter>
       </AuthProvider>

--- a/frontend/src/components/ResumeTailorForm/ResumeTailorForm.tsx
+++ b/frontend/src/components/ResumeTailorForm/ResumeTailorForm.tsx
@@ -4,15 +4,17 @@ import ResumeSelector from "../ResumeSelector/ResumeSelector";
 import TailoredResumeTable from "../TailoredResumeTable/TailoredResumeTable";
 import useUploadResumeFile from "../../hooks/useUploadResumeFile";
 import { useResumesContext } from "../../contexts/ResumesContext";
+import { useTailoredResumesContext } from "../../contexts/TailoredResumesContext.tsx";
 import { useResumeApi } from "../../api/resumeApi.ts";
 
 import "./ResumeTailorForm.css";
-import type Resume from "../../interfaces/Resume";
+import type { Resume } from "../../types/Resume.ts";
 
 type ResumeToTailor = Resume | null;
 
 export default function ResumeTailorForm() {
   const { selectedResume, tempUploadedResumeFile, setTempUploadedResumeFile, fetchResumes } = useResumesContext();
+  const { addNewTailoredResume } = useTailoredResumesContext();
   const { isUploading: isUploadingResume, uploadTemporaryFile } = useUploadResumeFile();
   const { tailorUserResume } = useResumeApi();
 
@@ -56,7 +58,7 @@ export default function ResumeTailorForm() {
       }
 
       const data = await response.json();
-      console.log(data);
+      addNewTailoredResume(data["tailoredResume"]);
 
       // Fetch user resumes if this tailoring request
       // involved uploading the user's first resume.

--- a/frontend/src/contexts/ResumesContext.tsx
+++ b/frontend/src/contexts/ResumesContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useReducer } from "react";
 
 import { useResumeApi } from "../api/resumeApi.ts";
 
-import type Resume from "../interfaces/Resume";
+import type { Resume } from "../types/Resume.ts";
 
 interface ResumesState {
   resumes: Resume[];

--- a/frontend/src/contexts/TailoredResumesContext.tsx
+++ b/frontend/src/contexts/TailoredResumesContext.tsx
@@ -39,7 +39,7 @@ function tailoredResumesReducer(state: TailoredResumesState, action: ResumesActi
     const newTailoredResumes = [...state.tailoredResumes];
     return {
       ...state,
-      tailoredResumes: [...newTailoredResumes, action.payload],
+      tailoredResumes: [action.payload, ...newTailoredResumes],
     }
   }
   if (action.type == "SET_ERROR") {

--- a/frontend/src/contexts/TailoredResumesContext.tsx
+++ b/frontend/src/contexts/TailoredResumesContext.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useContext, useReducer } from "react";
+
+import { useResumeApi } from "../api/resumeApi.ts";
+
+import type { TailoredResume } from "../types/TailoredResume.ts";
+
+interface TailoredResumesState {
+  tailoredResumes: TailoredResume[];
+  error: string;
+}
+
+interface TailoredResumesMethods {
+  fetchTailoredResumes: () => Promise<void>;
+  addNewTailoredResume: (tailoredResume: TailoredResume) => void;
+}
+
+const tailoredResumesInitialState: TailoredResumesState = {
+  tailoredResumes: [],
+  error: "",
+}
+
+type TailoredResumesContextType = TailoredResumesState & TailoredResumesMethods;
+
+export const TailoredResumesContext = createContext<TailoredResumesContextType | undefined>(undefined)
+
+type ResumesAction =
+  | { type: "SET_TAILORED_RESUMES"; payload: TailoredResume[]; }
+  | { type: "ADD_NEW_TAILORED_RESUME", payload: TailoredResume; }
+  | { type: "SET_ERROR", payload: string; };
+
+function tailoredResumesReducer(state: TailoredResumesState, action: ResumesAction) {
+  if (action.type == "SET_TAILORED_RESUMES") {
+    return {
+      ...state,
+      tailoredResumes: action.payload,
+    }
+  }
+  if (action.type == "ADD_NEW_TAILORED_RESUME") {
+    const newTailoredResumes = [...state.tailoredResumes];
+    return {
+      ...state,
+      tailoredResumes: [...newTailoredResumes, action.payload],
+    }
+  }
+  if (action.type == "SET_ERROR") {
+    return {
+      ...state,
+      error: action.payload,
+    }
+  }
+
+  return state;
+}
+
+export const TailoredResumesContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [tailoredResumesState, tailoredResumesDispatch] = useReducer(tailoredResumesReducer, tailoredResumesInitialState);
+  const { getTailoredUserResumes } = useResumeApi();
+
+  const handleAddNewTailoredResume = (tailoredResume: TailoredResume) => {
+    tailoredResumesDispatch({
+      type: "ADD_NEW_TAILORED_RESUME",
+      payload: tailoredResume,
+    })
+  };
+
+  // Async tailored resumes fetching function
+  const fetchTailoredResumes = async () => {
+    try {
+      const response = await getTailoredUserResumes();
+      const data: TailoredResume[] = await response.json();
+      tailoredResumesDispatch({ type: "SET_TAILORED_RESUMES", payload: data });
+    } catch (error) {
+      if (error instanceof Error) {
+        tailoredResumesDispatch({ type: "SET_ERROR", payload: error.message });
+      } else {
+        tailoredResumesDispatch({ type: "SET_ERROR", payload: "An error occurred." });
+      }
+    }
+  };
+
+  const ctxValue = {
+    tailoredResumes: tailoredResumesState.tailoredResumes,
+    error: tailoredResumesState.error,
+    fetchTailoredResumes,
+    addNewTailoredResume: handleAddNewTailoredResume,
+  }
+
+  return (
+    <TailoredResumesContext.Provider value={ctxValue} >
+      {children}
+    </TailoredResumesContext.Provider>
+  )
+}
+
+export const useTailoredResumesContext = (): TailoredResumesContextType => {
+  const context = useContext(TailoredResumesContext);
+  if (!context) throw new Error("useTailoredResumesContext must be used within TailoredResumesContextProvider");
+  return context;
+};

--- a/frontend/src/types/Resume.ts
+++ b/frontend/src/types/Resume.ts
@@ -1,4 +1,4 @@
-export default interface Resume {
+export type Resume = {
   id: number;
   name: string;
   is_default: boolean;

--- a/frontend/src/types/TailoredResume.ts
+++ b/frontend/src/types/TailoredResume.ts
@@ -1,0 +1,8 @@
+export type TailoredResume = {
+  id: number;
+  name: string;
+  company: string;
+  role: string;
+  job_posting_url: string;
+  created_at: string;
+}


### PR DESCRIPTION
### [SCRUM-94](https://tailorai.atlassian.net/browse/SCRUM-94)

### SUMMARY:
- Migrate tailored resumes functionality to a `TailoredResumesContext`
    - This will make tailored resumes consistent with user-uploaded resumes (which are managed by `ResumesContext`).
    - This will also help manage CRUD operations for tailored resumes (and its display updates in the `TailoredResumesTable` component).
- After a new tailored resume has been generated, it should appear in the Tailored Resumes table.
    - Currently, there is no indication that a new tailored resume was generated after clicking on the “Tailor Resume” button.

[SCRUM-94]: https://tailorai.atlassian.net/browse/SCRUM-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ