### PR TITLE
SCRUM-104: Migrate environment variables and secrets

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,10 +24,10 @@ jobs:
     services:
       postgres:
         image: postgres:latest
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: github_actions
+        env: # Retrieved from Github Secrets/Variables
+          POSTGRES_DB: ${GIT_POSTGRES_DB}
+          POSTGRES_USER: ${GIT_POSTGRES_USER}
+          POSTGRES_PASSWORD: ${GIT_POSTGRES_PASSWORD}
         ports:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
@@ -46,8 +46,6 @@ jobs:
     - name: Run migrations
       env:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}
       run: python manage.py migrate
     - name: Lint with ruff
       run: ruff check --output-format=github --target-version=py310
@@ -57,8 +55,6 @@ jobs:
     - name: Test with pytest
       env:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}
       run: |
         coverage run -m pytest  -v -s
     - name: Generate Coverage Report

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,9 +25,9 @@ jobs:
       postgres:
         image: postgres:latest
         env: # Retrieved from Github Secrets/Variables
-          POSTGRES_DB: ${GIT_POSTGRES_DB}
-          POSTGRES_USER: ${GIT_POSTGRES_USER}
-          POSTGRES_PASSWORD: ${GIT_POSTGRES_PASSWORD}
+          POSTGRES_DB: ${{ vars.GIT_POSTGRES_DB }}
+          POSTGRES_USER: ${{ vars.GIT_POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ secrets.GIT_POSTGRES_PASSWORD }}
         ports:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,6 +45,9 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Run migrations
       env:
+        POSTGRES_DB: ${{ vars.GIT_POSTGRES_DB }}
+        POSTGRES_USER: ${{ vars.GIT_POSTGRES_USER }}
+        POSTGRES_PASSWORD: ${{ secrets.GIT_POSTGRES_PASSWORD }}
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}
@@ -56,6 +59,9 @@ jobs:
       continue-on-error: true
     - name: Test with pytest
       env:
+        POSTGRES_DB: ${{ vars.GIT_POSTGRES_DB }}
+        POSTGRES_USER: ${{ vars.GIT_POSTGRES_USER }}
+        POSTGRES_PASSWORD: ${{ secrets.GIT_POSTGRES_PASSWORD }}
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,6 +46,8 @@ jobs:
     - name: Run migrations
       env:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}
       run: python manage.py migrate
     - name: Lint with ruff
       run: ruff check --output-format=github --target-version=py310
@@ -55,6 +57,8 @@ jobs:
     - name: Test with pytest
       env:
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GOOGLE_OAUTH_CLIENT_ID }}
       run: |
         coverage run -m pytest  -v -s
     - name: Generate Coverage Report

--- a/backend/resumai/settings.py
+++ b/backend/resumai/settings.py
@@ -95,10 +95,10 @@ if os.environ.get("GITHUB_WORKFLOW"):
     DATABASES = {
         "default": {
            "ENGINE": "django.db.backends.postgresql",
-           "NAME": env("GIT_POSTGRES_DB"), # Retrieved from Github Secrets/Variables
-           "USER": env("GIT_POSTGRES_USER"),# Retrieved from Github Secrets/Variables
-           "PASSWORD": env("GIT_POSTGRES_PASSWORD"),# Retrieved from Github Secrets/Variables
-           "HOST": "127.0.0.1",
+           "NAME": env("POSTGRES_DB"), # Retrieved from Github Secrets/Variables
+           "USER": env("POSTGRES_USER"), # Retrieved from Github Secrets/Variables
+           "PASSWORD": env("POSTGRES_PASSWORD"), # Retrieved from Github Secrets/Variables
+           "HOST": "localhost",
            "PORT": "5432",
         }
     }

--- a/backend/resumai/settings.py
+++ b/backend/resumai/settings.py
@@ -13,7 +13,7 @@ if os.getenv("IS_RUNNING_IN_CONTAINER"):
 # Load environment variables from file (only for local development)
 # If file not available, env() reads from runtime environment (i.e. Docker)
 env = environ.Env()
-env_file = os.path.join(BASE_DIR, f".env.local")
+env_file = os.path.join(BASE_DIR, ".env.local")
 if os.path.exists(env_file):
     env.read_env(env_file)
 

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,10 +1,8 @@
 services:
   db:
     image: postgres:17-alpine
-    environment:
-      POSTGRES_DB: ${DATABASE_NAME}
-      POSTGRES_USER: ${DATABASE_USERNAME}
-      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+    # env file must define POSTGRES_DB, POSTGRES_USER, and POSTGRES_PASSWORD
+    env_file: ./backend/.env.local
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
       interval: 5s
@@ -29,8 +27,9 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./backend:/backend
-    env_file: ./backend/.env.local
+      - ./backend:/backend # bind-mount syncs all files in folder, ignores .dockerignore rules
+    environment:
+      IS_RUNNING_IN_CONTAINER: "true"
   web:
     build: 
       context: ./frontend
@@ -38,10 +37,9 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./frontend:/frontend
+      - ./frontend:/frontend # bind-mount syncs all files in folder, ignores .dockerignore rules
       - /frontend/node_modules
     environment:
       NODE_ENV: development
-    env_file: ./frontend/.env.local
 volumes:
    postgres_data:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,9 +1,9 @@
 services:
   db:
     image: postgres:17-alpine
-    environment:
+    environment: # Retrieved from Github Secrets/Variables
       POSTGRES_DB: ${DATABASE_NAME}
-      POSTGRES_USER: ${DATABASE_USERNAME}
+      POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
@@ -14,7 +14,6 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    # TODO: Change Postgres login for Prod
   api:
     build: 
       context: ./backend
@@ -24,7 +23,18 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    env_file: ./backend/.env.prod
+    environment: # Retrieved from Github Secrets/Variables
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      DEBUG: ${DEBUG}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      DATABASE_ENGINE: ${DATABASE_ENGINE}
+      DATABASE_NAME: ${DATABASE_NAME}
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+      DATABASE_HOST: ${DATABASE_HOST}
+      DATABASE_PORT: ${DATABASE_PORT}
   web:
     build: 
       context: ./frontend
@@ -35,6 +45,7 @@ services:
       - /frontend/node_modules
     environment:
       NODE_ENV: production
-    env_file: ./frontend/.env.prod
+      VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+      VITE_GOOGLE_OAUTH_CLIENT_ID: ${VITE_GOOGLE_OAUTH_CLIENT_ID}
 volumes:
    postgres_data:


### PR DESCRIPTION
# [SCRUM-104](https://tailorai.atlassian.net/browse/SCRUM-104)

### SUMMARY:
- Local development and local Docker will use `.env.local` file to populate environment variables and secrets.
- Github workflow and Production will reference actual environment variables, populated via GitHub Secrets and Variables.
    - This avoids storing Production secrets and variables in `.env.prod` files, since those should be in a secrets manager (AWS for example, but GitHub for now).


[SCRUM-104]: https://tailorai.atlassian.net/browse/SCRUM-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ